### PR TITLE
Suggestions for the `purescript-either` section

### DIFF
--- a/ecosystem-changes.md
+++ b/ecosystem-changes.md
@@ -151,7 +151,7 @@ This counts as a breaking change because data types that implemented `Foldable1`
 
 One could pass a `Number` value that isn't a valid 32-bit integer, which might cause a runtime error to occur. The implementation of this function needs a `Number` value so that truncation doesn't occur. To support both goals, the implementation now converts the `Int` argument to a `Number` before it gets used internally.
 
-### `purescript-either`'s `fromLeft` and `fromRight` are now total functions, not partial functions like `fromMaybe`
+### `purescript-either`'s `fromLeft` and `fromRight` are not partial functions anymore (like `Data.Maybe.fromJust`) but total functions (like `Data.Maybe.fromMaybe`)
 
 **Summary**
 - Type signatures now include a default value

--- a/ecosystem-changes.md
+++ b/ecosystem-changes.md
@@ -157,7 +157,7 @@ One could pass a `Number` value that isn't a valid 32-bit integer, which might c
 - Type signatures now include a default value
     - Before: `fromLeft :: forall a b. Partial => Either a b -> a`
     - After: `fromLeft :: forall a b. a -> Either a b -> a`
-- Usages of `unsafePartial <<< fromRight` should be replaced with `either (\_ -> unsafeCrashWith "failure message here") identity`
+- Usages of `unsafePartial <<< fromRight` should be replaced with `fromRight' (\_ -> unsafeCrashWith "failure message here")`
 
 ### `purescript-control`'s `MonadZero` has been deprecated
 

--- a/ecosystem-changes.md
+++ b/ecosystem-changes.md
@@ -151,7 +151,7 @@ This counts as a breaking change because data types that implemented `Foldable1`
 
 One could pass a `Number` value that isn't a valid 32-bit integer, which might cause a runtime error to occur. The implementation of this function needs a `Number` value so that truncation doesn't occur. To support both goals, the implementation now converts the `Int` argument to a `Number` before it gets used internally.
 
-### `purescript-either`'s `unsafeLeft` and `unsafeRight` are now total functions, not partial functions like `fromMaybe`
+### `purescript-either`'s `fromLeft` and `fromRight` are now total functions, not partial functions like `fromMaybe`
 
 **Summary**
 - Type signatures now include a default value


### PR DESCRIPTION
This pull request fixes a typo (unsafeLeft and unsafeRight don’t exist), rephrases the title of the section (the current formulation seems to imply that fromMaybe is partial, but perhaps I’m misreading it) and suggests `fromRight' (\_ -> unsafeCrashWith "failure message here")` instead of `either (\_ -> unsafeCrashWith "failure message here") identity` to replace `unsafePartial <<< fromRight`.